### PR TITLE
feat: add ttl time configuration

### DIFF
--- a/lib/osml/model_runner/mr_dataplane.ts
+++ b/lib/osml/model_runner/mr_dataplane.ts
@@ -126,6 +126,12 @@ export class MRDataplaneConfig extends BaseConfig {
   public DDB_TTL_ATTRIBUTE: string;
 
   /**
+   * The time to live in days for DDB records used in tables.
+   * @default undefined
+   */
+  public DDB_TTL_IN_DAYS: string;
+
+  /**
    * The maximum number of tasks allowed in the cluster.
    * @default 40
    */
@@ -767,6 +773,7 @@ export class MRDataplane extends Construct {
   } {
     let containerEnv = {
       AWS_DEFAULT_REGION: props.account.region,
+      DDB_TTL_IN_DAYS: this.config.DDB_TTL_IN_DAYS,
       JOB_TABLE: this.jobStatusTable.table.tableName,
       OUTSTANDING_JOBS_TABLE: this.outstandingImageJobsTable.table.tableName,
       FEATURE_TABLE: this.featureTable.table.tableName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osml-cdk-constructs",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osml-cdk-constructs",
-      "version": "2.0.8",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@cdklabs/cdk-enterprise-iac": "^0.1.0",
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^8.29.0",
         "@typescript-eslint/parser": "^8.29.0",
         "aws-cdk": "^2.1007.0",
-        "aws-cdk-lib": "^2.187.0",
+        "aws-cdk-lib": "^2.189.1",
         "cdk-nag": "^2.35.61",
         "constructs": "^10.4.2",
         "eslint": "^9.23.0",
@@ -51,11 +51,10 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.230",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.230.tgz",
-      "integrity": "sha512-kUnhKIYu42hqBa6a8x2/7o29ObpJgjYGQy28lZDq9awXyvpR62I2bRxrNKNR3uFUQz3ySuT9JXhGHhuZPdbnFw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "2.2.237",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.237.tgz",
+      "integrity": "sha512-OlXylbXI52lboFVJBFLae+WB99qWmI121x/wXQHEMj2RaVNVbWE+OAHcDk2Um1BitUQCaTf9ki57B0Fuqx0Rvw==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
@@ -2379,9 +2378,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.187.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.187.0.tgz",
-      "integrity": "sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==",
+      "version": "2.199.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.199.0.tgz",
+      "integrity": "sha512-hAZHdb7bPHepIGpuyg0jS/F3toY7VRvJDqxo4+C2cYY5zvktGP3lgcC9ukE2ehxYU1Pa9YOAehEDIxrita0Hvw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2396,11 +2395,10 @@
         "mime-types"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-awscli-v1": "2.2.237",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.2.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",
@@ -2409,7 +2407,7 @@
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.7.1",
+        "semver": "^7.7.2",
         "table": "^6.9.0",
         "yaml": "1.10.2"
       },
@@ -2675,7 +2673,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",
     "aws-cdk": "^2.1007.0",
-    "aws-cdk-lib": "^2.187.0",
+    "aws-cdk-lib": "^2.189.1",
     "cdk-nag": "^2.35.61",
     "constructs": "^10.4.2",
     "eslint": "^9.23.0",


### PR DESCRIPTION
**Issue #, if available:** [PR](https://github.com/awslabs/osml-model-runner/issues/126)

Problem:
The default TTL for DynamoDB tables is hardcoded to 24 hours (1 day), with no option for users to customize this in their deployments. This limits flexibility for different retention needs across environments or use cases.

Solution:
Added support for a configurable DDB_TTL_IN_DAYS CDK context or stack parameter. This allows users to specify the number of days for DynamoDB TTL directly in their infrastructure definitions.
If no value is provided, the TTL defaults to 1 day (24 hours) to preserve current behavior.

Changes include:
	•	Introduced DDB_TTL_IN_DAYS as a new parameter in the CDK stack.
	•	Passed this value to the DynamoDB table TTL configuration.
	•	Updated documentation and default stacks to reflect this change.
### Notes


### Checklist

Before you submit a pull request, please make sure you have the following:
- [ ] Code changes are compact and well-structured to facilitate easy review
- [ ] Changes are documented in the README.md and other relevant documentation pages
- [ ] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [ ] PR contains tests that cover all new code and the code has been manual tested
- [ ] All new dependencies are declared (if any), and no unnecessary libraries are added
- [ ] Performance impacts (if any) of the changes are evaluated and documented
- [ ] Security implications of the changes (if any) are reviewed and addressed
- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
